### PR TITLE
Remove scanDirectories from PHPStan config

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -2,7 +2,5 @@ parameters:
   level: max
   paths:
     - src
-  scanDirectories:
-    - src
   bootstrapFiles:
     - tests/stubs.php


### PR DESCRIPTION
PHPStan scans directories in `paths`