### PR TITLE
Run tests on PHP 8.1 also

### DIFF
--- a/.github/workflows/php-standards.yml
+++ b/.github/workflows/php-standards.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     strategy:
       matrix:
-        php: ['7.4', '8.0']
+        php: ['7.4', '8.0', '8.1']
       fail-fast: false
     name: PHP Coding Standards
     runs-on: ubuntu-18.04
@@ -25,11 +25,6 @@ jobs:
       with:
         php-version: ${{ matrix.php }}
         coverage: none
-
-    - name: Debugging
-      run: |
-        php --version
-        composer --version
 
     - name: Get Composer Cache Directory
       id: composer-cache-dir
@@ -45,7 +40,7 @@ jobs:
 
     - name: Install PHP Dependencies
       run: |
-        composer install --prefer-dist --no-progress --no-suggest --no-interaction
+        composer update --prefer-dist --no-progress --no-interaction
 
     - name: Run the tests
       run: |


### PR DESCRIPTION
- https://www.php.net/releases/8.1/en.php
- we don't have a lock file, so `composer update`
- `--no-suggest` is deprecated
- Debugging is already displayed 👇 

![kép](https://user-images.githubusercontent.com/952007/146272789-5f8bd367-e244-4f68-8380-2e238b5fbabf.png)
