### PR TITLE
Ignore specific PHPStan error in tests

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -12,5 +12,3 @@ parameters:
     - tests
   bootstrapFiles:
     - tests/stubs.php
-  ignoreErrors:
-    - '#Access to an undefined property Args#'

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -12,3 +12,7 @@ parameters:
     - tests
   bootstrapFiles:
     - tests/stubs.php
+  ignoreErrors:
+    -
+      message: '#^Access to an undefined property Args\\#'
+      path: tests/phpunit/ConversionToArrayTest.php


### PR DESCRIPTION
It would be much better to use `// @phpstan-ignore-next-line` locally.
@johnbillion What do you think?