### PR TITLE
Avoid using `mixed` type hint for compatibility with PHP 7.4

### DIFF
--- a/src/register_meta.php
+++ b/src/register_meta.php
@@ -49,8 +49,10 @@ class register_meta extends Shared\Base {
 	 * The default value returned from `get_metadata()` if no value has been set yet.
 	 *
 	 * When using a non-single meta key, the default value is for the first entry. In other words, when calling `get_metadata()` with `$single` set to `false`, the default value given here will be wrapped in an array.
+	 *
+	 * @var mixed
 	 */
-	public mixed $default;
+	public $default;
 
 	/**
 	 * A function or method to call when sanitizing `$meta_key` data.


### PR DESCRIPTION
`mixed` as a type hint was introduced in PHP 8.0. Thus when using Args with PHP 7.4 you'll get a fatal error:

```
Fatal error: Uncaught Error: Typed property Args\register_meta::$default must be an instance of Args\mixed, string used in ...
```

I think we can remove the type hint and use `@var` instead.