### PR TITLE
Fix types on WP_Http::$headers

### DIFF
--- a/src/WP_Http.php
+++ b/src/WP_Http.php
@@ -88,7 +88,7 @@ class WP_Http extends Shared\Base {
 	 *
 	 * Default empty array.
 	 *
-	 * @var array<int,string>
+	 * @var array<string,string>
 	 */
 	public array $headers;
 

--- a/tests/WP_Http.php
+++ b/tests/WP_Http.php
@@ -29,7 +29,7 @@ $args->user_agent = 'Args';
 $args->reject_unsafe_urls = true;
 $args->blocking = false;
 $args->headers = [
-	'Foo: Bar',
+	'Foo' => 'Bar',
 ];
 $args->cookies = [];
 $args->body = 'Hello';


### PR DESCRIPTION
The `\WpOrg\Requests\Requests` class expected headers to be in `key` => `value` format.

1. `\WpOrg\Requests\Requests::flatten` converts a `[key => value]` array into header format.
2. `\WpOrg\Requests\Transport\Curl::setup_handle` calls `flatten`.

If headers as passed as `<int, string>` as they were typed, they get jumbled into "<number>: header".

Example

```php
$args = new WP_Http();
$args->headers = [
    'Accept: application/json'
];
```
Becomes
```php
array( '0: Accept: application/json' );
```
Whereas
```php
$args->headers = [
    'Accept' => 'application/json'
];
```
Becomes

```php
array( 'Accept: application/json' );
```

