### PR TITLE
Complete the `WP_Block_Type::$render_callback` property

### DIFF
--- a/src/WP_Block_Type.php
+++ b/src/WP_Block_Type.php
@@ -97,7 +97,7 @@ class WP_Block_Type extends Shared\Base {
 	 * Block type render callback.
 	 *
 	 * @var callable
-	 * @phpstan-var callable(array<string, mixed>, string): string
+	 * @phpstan-var callable( array<string, mixed>, string, ?\WP_Block ): string
 	 */
 	public $render_callback;
 

--- a/src/WP_Block_Type.php
+++ b/src/WP_Block_Type.php
@@ -97,7 +97,7 @@ class WP_Block_Type extends Shared\Base {
 	 * Block type render callback.
 	 *
 	 * @var callable
-	 * @phpstan-var callable( array<string, mixed>, string, ?\WP_Block ): string
+	 * @phpstan-var callable( array<string, mixed>, string, \WP_Block= ): string
 	 */
 	public $render_callback;
 

--- a/tests/stubs.php
+++ b/tests/stubs.php
@@ -12,6 +12,8 @@ final class WP_Taxonomy {}
 
 abstract class WP_REST_Controller {}
 
+class WP_Block {}
+
 class WP_REST_Request {}
 
 class WP_Http_Cookie {}


### PR DESCRIPTION
The callback supports 3 parameters
1. Attributes -> array
2. Content -> string
3. Block Object -> \WP_Block

Argument #3 is available under dynamic rendering context as seen here. https://github.com/WordPress/WordPress/blob/e3d1a1291fd3bbfdca3af409e8007d35f2109fa4/wp-includes/class-wp-block.php#L258

In some circumstances (e.g. Legacy widget iframe) argument #3 is not provided. Hence the optional `=`. https://github.com/WordPress/WordPress/blob/e3d1a1291fd3bbfdca3af409e8007d35f2109fa4/wp-includes/class-wp-block-type.php#L398