### PR TITLE
Fix settings include_children on TaxQuery Clauses

### DIFF
--- a/src/TaxQuery/Clause.php
+++ b/src/TaxQuery/Clause.php
@@ -59,7 +59,29 @@ final class Clause implements Arrayable, Values {
 	/**
 	 * Whether to include child terms. Requires a `$taxonomy`.
 	 *
+	 * @alias include_children
+	 *
 	 * Default: true.
 	 */
 	public bool $children;
+
+	/**
+	 * Whether to include child terms. Requires a `$taxonomy`.
+	 *
+	 * Default: true.
+	 */
+	public bool $include_children;
+
+	/**
+	 * @return array<string,mixed>
+	 */
+	final public function toArray(): array {
+		$vars = get_object_vars( $this );
+		if ( isset( $this->children ) && ! isset( $this->include_children ) ) {
+			$vars['include_children'] = $this->children;
+		}
+		\ksort( $vars );
+
+		return $vars;
+	}
 }

--- a/tests/phpunit/TaxQueryTest.php
+++ b/tests/phpunit/TaxQueryTest.php
@@ -105,4 +105,46 @@ final class TaxQueryTest extends TestCase {
 
 		self::assertSame( $expected, $actual );
 	}
+
+	/**
+	 * @dataProvider dataWithTaxQueryArgs
+	 * @param WithTax $class
+	 */
+	public function testTaxQueryChildrenBackwardCompatibility( string $class ): void {
+		$args = new $class;
+
+		$clause1 = new Clause;
+		$clause1->taxonomy = 'category';
+		$clause1->terms = 'foo';
+		$clause1->include_children = true;
+
+		$clause2 = new Clause;
+		$clause2->terms = 456;
+		$clause2->operator = 'EXISTS';
+		$clause2->children = false;
+
+		$args->tax_query->relation = Values::TAX_QUERY_RELATION_OR;
+		$args->tax_query->addClause( $clause1 );
+		$args->tax_query->addClause( $clause2 );
+
+		$expected = [
+			'tax_query' => [
+				'relation' => 'OR',
+				[
+					'include_children' => true,
+					'taxonomy' => 'category',
+					'terms' => 'foo',
+				],
+				[
+					'children' => false,
+					'include_children' => false,
+					'operator' => 'EXISTS',
+					'terms' => 456,
+				],
+			],
+		];
+		$actual = $args->toArray();
+
+		self::assertSame( $expected, $actual );
+	}
 }


### PR DESCRIPTION
The key of the tax_query argument is `include_children`  vs the existing `children` property.
- Introduce a new `include_children` setting on the TaxQuery Clause.
- Alias the existing `children` setting to `include_children` for backward compatibility.