### PR TITLE
Fix DateQuery parameter type annotations to match WordPress core

### DIFF
--- a/src/DateQuery/Clause.php
+++ b/src/DateQuery/Clause.php
@@ -90,13 +90,13 @@ final class Clause implements Arrayable, Values {
 	public int|array $month;
 
 	/**
-	 * The week number of the year. Accepts numbers 0-53 or an
+	 * The week number of the year. Accepts numbers 1-53 or an
 	 * array of valid numbers if `$compare` supports it.
 	 *
 	 * Default empty.
 	 *
 	 * @var int|array<int,int>
-	 * @phpstan-var int<0,53>|list<int<0,53>>
+	 * @phpstan-var int<1,53>|list<int<1,53>>
 	 */
 	public int|array $week;
 
@@ -151,7 +151,7 @@ final class Clause implements Arrayable, Values {
 	 * Default empty.
 	 *
 	 * @var int|array<int,int>
-	 * @phpstan-var int<1,23>|list<int<1,23>>
+	 * @phpstan-var int<0,23>|list<int<0,23>>
 	 */
 	public int|array $hour;
 


### PR DESCRIPTION
Corrects PHPStan type annotations for date query parameters to align
with WordPress core WP_Date_Query validation:

- hour: Changed from int<1,23> to int<0,23> to include 0
  (WordPress accepts 0-23, see WP_Date_Query lines 136, 374-377)

- week: Changed from int<0,53> to int<1,53> to match validation
  (WordPress validates min=1, see WP_Date_Query lines 362-365)

These changes ensure type hints accurately reflect WordPress core's
actual validation rules.